### PR TITLE
Fix opcode 17

### DIFF
--- a/src/definitions/achievements.rs
+++ b/src/definitions/achievements.rs
@@ -63,6 +63,7 @@ pub struct Achievement {
     pub reqs_23: Option<Vec<PackedVarbitRequirement>>,
     pub reqs_25: Option<Vec<PackedVarbitRequirement>>,
     pub unknown_27: Option<bool>,
+    pub unknown_17: Option<bool>, //
     pub skill_req_count: Option<Vec<u8>>,
 
     /// 355 - Seven Colours in Their Hat - 1
@@ -186,6 +187,7 @@ impl Achievement {
                     }
                 }
                 16 => achievement.sub_category = Some(buffer.get_u16()),
+                17 => achievement.unknown_17 = Some(true),
                 18 => achievement.hidden = Some(buffer.get_u8()),
                 19 => achievement.free_to_play = Some(true),
                 20 => {


### PR DESCRIPTION
```
>rs3cache.exe --dump achievements
```

```
thread 'main' panicked at 'not implemented: Achievement::deserialize cannot deserialize opcode 17 in id 1855:
 {
  "id": 1855
}', src\definitions\achievements.rs:242:28
```
After fix achievements.json is generated as expected.

Unsure if correct type is used for opcode 17 but it works.