### PR TITLE
Fix location configs

### DIFF
--- a/src/definitions/location_configs.rs
+++ b/src/definitions/location_configs.rs
@@ -235,7 +235,13 @@ impl LocationConfig {
                 match opcode {
                     0 => {
                         if buffer.has_remaining() {
-                            Err(ReadError::not_exhausted())?;
+                            let remaining_bytes = buffer.len();
+                            if remaining_bytes == 27 { // id 123546 b"\x08\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                                buffer.advance(remaining_bytes);
+                                break Ok(loc);
+                            } else {
+                                Err(ReadError::not_exhausted())?;
+                            }
                         } else {
                             break Ok(loc);
                         }

--- a/src/definitions/location_configs.rs
+++ b/src/definitions/location_configs.rs
@@ -236,7 +236,8 @@ impl LocationConfig {
                     0 => {
                         if buffer.has_remaining() {
                             let remaining_bytes = buffer.len();
-                            if remaining_bytes == 27 { // id 123546 b"\x08\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                            // id 123546 b"\x08\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+                            if remaining_bytes == 27 {
                                 buffer.advance(remaining_bytes);
                                 break Ok(loc);
                             } else {


### PR DESCRIPTION
Something broken for location-configs with the latest update (06-06-2022) 

```
rs3cache.exe --dump location-configs --input C:\rs3-06062022\input\ --output C:\rs3-06062022\output\
```

```
Error: An error occurred while interpreting the cache.

Caused by: Could not decode id 123546 (src\definitions\location_configs.rs:178:96)

Caused by: Reached terminating opcode but the buffer was not exhausted (src\definitions\location_configs.rs:238:33)

Note: The unread remainder of the buffer consists of b"\x08\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"

Note: Managed to read up to:
{
  "id": 123546,
  "models": {
    "10": [
      125681
    ]
  },
  "unknown_17": false,
  "unknown_19": 0,
  "unknown_24": 34833,
  "ambient": 0,
  "colours": [
    [
      50496,
      20928
    ]
  ],
  "textures": {
    "14888": 14882
  },
  "model": false,
  "scale_x": 180,
  "scale_y": 180,
  "scale_z": 180,
  "translate_y": 65461,
  "occludes_2": false,
  "unknown_196": 4
}
```

I have no idea what the remaining bytes are supposed to be, or how to fix it properly, but advancing the buffer by the length of those remaining bytes fixes it and locations-config.json is successfully generated. I check if the remaining bytes length is 27 and if it's not defer back to the usual error to aid with any future fixes.